### PR TITLE
Fixed another typo, changed "groudn" to "ground"

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 Ground Beef MC is a mod that adds some long-needed features to minecraft. It adds a naturally generating ground beef ore, raw and cooked ground beef and the ability to craft them into steaks, just like how it works in the real world.
 
-Ground Beef will spawn between y=0 to y=60. They can be broken with an Iron Pickaxe and better. Breaking a Groudn Beef Ore will drop itself. This can be smelted in a furnace to make ground beef.
+Ground Beef will spawn between y=0 to y=60. They can be broken with an Iron Pickaxe and better. Breaking a Ground Beef Ore will drop itself. This can be smelted in a furnace to make ground beef.
 
 You can add 2 ground beefs in a crafting table to make a Raw Steak. You can also cook this ground beef in a furnace to make cooked ground beef, which can be made into Cooked Steak. Ground Beef and Cooked Ground Beef can both be eaten, but Raw Ground Beef may give you food poisoning. This is an essential mod to any modded game to give an extra sense of realism.
 


### PR DESCRIPTION
(Typo was at "Breaking a Ground Beef Ore will drop itself")